### PR TITLE
Add UE5 TacSim skeleton with scenario loader

### DIFF
--- a/Content/Scenarios/example_scenario.json
+++ b/Content/Scenarios/example_scenario.json
@@ -1,0 +1,261 @@
+{
+  "scenario": {
+    "name": "Five-Stage Daylight Raid",
+    "location": "Lebanon",
+    "time_of_day": "daytime",
+    "environment": {
+      "map_asset": "/Game/Maps/UrbanTownhouse01"
+    },
+    "building": {
+      "type": "Townhouse_3Floor",
+      "location": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "rotation": {
+        "yaw": 90
+      }
+    },
+    "actors": [
+      {
+        "id": "BlueLeader",
+        "type": "Friendly",
+        "spawn": {
+          "x": -100,
+          "y": 0,
+          "z": 0
+        },
+        "role": "TeamLeader"
+      },
+      {
+        "id": "BlueBreacher",
+        "type": "Friendly",
+        "spawn": {
+          "x": -110,
+          "y": 10,
+          "z": 0
+        },
+        "role": "Breacher"
+      },
+      {
+        "id": "RedDefender1",
+        "type": "Enemy",
+        "spawn": {
+          "x": 5,
+          "y": 5,
+          "z": 0
+        },
+        "role": "Sentry"
+      },
+      {
+        "id": "RedDefender2",
+        "type": "Enemy",
+        "spawn": {
+          "x": 5,
+          "y": -5,
+          "z": 300
+        },
+        "role": "Rifleman"
+      }
+    ],
+    "stages": [
+      {
+        "stage": 1,
+        "name": "First Move toward Objective",
+        "decisions": {
+          "A": {
+            "description": "Suppressive fire on the house",
+            "effects": {
+              "audio": [
+                "Audio/GunfireLoop"
+              ],
+              "visual": [
+                "FX/MuzzleFlash"
+              ]
+            }
+          },
+          "B": {
+            "description": "Launch a daylight drone for recon",
+            "effects": {
+              "audio": [
+                "Audio/DroneBuzz"
+              ],
+              "visual": [
+                "Drone/DroneModel"
+              ]
+            }
+          },
+          "C": {
+            "description": "Silent breach attempt",
+            "effects": {
+              "audio": [
+                "Audio/FootstepsQuiet"
+              ],
+              "visual": [
+                "None"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "stage": 2,
+        "name": "Point of Entry",
+        "decisions": {
+          "A": {
+            "description": "Main door entry (fast, risk of booby-trap)",
+            "effects": {
+              "audio": [
+                "Audio/DoorCreak"
+              ],
+              "visual": [
+                "FX/Flashbang"
+              ]
+            }
+          },
+          "B": {
+            "description": "Explosive wall breach",
+            "effects": {
+              "audio": [
+                "Audio/ExplosionSmall"
+              ],
+              "visual": [
+                "FX/WallRubble"
+              ]
+            }
+          },
+          "C": {
+            "description": "Flank through brush and rear entry",
+            "effects": {
+              "audio": [
+                "Audio/LeafRustle"
+              ],
+              "visual": [
+                "Brush/FoliageRustle"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "stage": 3,
+        "name": "Clearing the Interior",
+        "decisions": {
+          "A": {
+            "description": "Bottom-up blitz",
+            "effects": {
+              "audio": [
+                "Audio/StairsFootsteps",
+                "Audio/GunfireShort"
+              ],
+              "visual": [
+                "FX/RoomClearFlash"
+              ]
+            }
+          },
+          "B": {
+            "description": "Direct-to-cellar first",
+            "effects": {
+              "audio": [
+                "Audio/LadderClimb"
+              ],
+              "visual": [
+                "FX/CellarEntrySmoke"
+              ]
+            }
+          },
+          "C": {
+            "description": "Slice & hold, one level at a time",
+            "effects": {
+              "audio": [
+                "Audio/ClearRoomEcho"
+              ],
+              "visual": [
+                "FX/RoomClearSmoke"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "stage": 4,
+        "name": "Unknown External Gunfire",
+        "decisions": {
+          "A": {
+            "description": "Halt and fortify inside",
+            "effects": {
+              "audio": [
+                "Audio/FortifyNoise"
+              ],
+              "visual": [
+                "FX/WindowBarricade"
+              ]
+            }
+          },
+          "B": {
+            "description": "Deploy drone while clearing",
+            "effects": {
+              "audio": [
+                "Audio/DroneBuzz"
+              ],
+              "visual": [
+                "Drone/DronePing"
+              ]
+            }
+          },
+          "C": {
+            "description": "Continue clearing with extra lookouts",
+            "effects": {
+              "audio": [
+                "Audio/GunfireShort"
+              ],
+              "visual": [
+                "FX/LookoutFlash"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "stage": 5,
+        "name": "Exfiltration Plan",
+        "decisions": {
+          "A": {
+            "description": "Defensive perimeter, call vehicles",
+            "effects": {
+              "audio": [
+                "Audio/RadioCall"
+              ],
+              "visual": [
+                "Vehicles/ArmoredVehicle"
+              ]
+            }
+          },
+          "B": {
+            "description": "Silent fade through brush",
+            "effects": {
+              "audio": [
+                "Audio/FootstepsQuiet"
+              ],
+              "visual": [
+                "Brush/FoliageRustle"
+              ]
+            }
+          },
+          "C": {
+            "description": "Noisy bounding breakout",
+            "effects": {
+              "audio": [
+                "Audio/GunfireLoop"
+              ],
+              "visual": [
+                "FX/FlashbangMultiple"
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/Content/Scenarios/example_scenario.yaml
+++ b/Content/Scenarios/example_scenario.yaml
@@ -1,0 +1,129 @@
+# example_scenario.yaml
+# Phase 2.5 "Five-Stage Daylight Raid – Lebanon"
+
+scenario:
+  name: "Five-Stage Daylight Raid"
+  location: "Lebanon"
+  time_of_day: "daytime"
+
+  environment:
+    map_asset: "/Game/Maps/UrbanTownhouse01"
+
+  building:
+    type: "Townhouse_3Floor"
+    location: { x: 0, y: 0, z: 0 }
+    rotation: { yaw: 90 }
+
+  actors:
+    - id: "BlueLeader"
+      type: "Friendly"
+      spawn: { x: -100, y: 0, z: 0 }
+      role: "TeamLeader"
+    - id: "BlueBreacher"
+      type: "Friendly"
+      spawn: { x: -110, y: 10, z: 0 }
+      role: "Breacher"
+    - id: "RedDefender1"
+      type: "Enemy"
+      spawn: { x: 5, y: 5, z: 0 }
+      role: "Sentry"
+    - id: "RedDefender2"
+      type: "Enemy"
+      spawn: { x: 5, y: -5, z: 300 }
+      role: "Rifleman"
+
+  stages:
+    - stage: 1
+      name: "First Move toward Objective"
+      decisions:
+        A:
+          description: "Suppressive fire on the house"
+          effects:
+            audio: ["Audio/GunfireLoop"]
+            visual: ["FX/MuzzleFlash"]
+        B:
+          description: "Launch a daylight drone for recon"
+          effects:
+            audio: ["Audio/DroneBuzz"]
+            visual: ["Drone/DroneModel"]
+        C:
+          description: "Silent breach attempt"
+          effects:
+            audio: ["Audio/FootstepsQuiet"]
+            visual: ["None"]
+
+    - stage: 2
+      name: "Point of Entry"
+      decisions:
+        A:
+          description: "Main door entry (fast, risk of booby-trap)"
+          effects:
+            audio: ["Audio/DoorCreak"]
+            visual: ["FX/Flashbang"]
+        B:
+          description: "Explosive wall breach"
+          effects:
+            audio: ["Audio/ExplosionSmall"]
+            visual: ["FX/WallRubble"]
+        C:
+          description: "Flank through brush and rear entry"
+          effects:
+            audio: ["Audio/LeafRustle"]
+            visual: ["Brush/FoliageRustle"]
+
+    - stage: 3
+      name: "Clearing the Interior"
+      decisions:
+        A:
+          description: "Bottom-up blitz"
+          effects:
+            audio: ["Audio/StairsFootsteps", "Audio/GunfireShort"]
+            visual: ["FX/RoomClearFlash"]
+        B:
+          description: "Direct-to-cellar first"
+          effects:
+            audio: ["Audio/LadderClimb"]
+            visual: ["FX/CellarEntrySmoke"]
+        C:
+          description: "Slice & hold, one level at a time"
+          effects:
+            audio: ["Audio/ClearRoomEcho"]
+            visual: ["FX/RoomClearSmoke"]
+
+    - stage: 4
+      name: "Unknown External Gunfire"
+      decisions:
+        A:
+          description: "Halt and fortify inside"
+          effects:
+            audio: ["Audio/FortifyNoise"]
+            visual: ["FX/WindowBarricade"]
+        B:
+          description: "Deploy drone while clearing"
+          effects:
+            audio: ["Audio/DroneBuzz"]
+            visual: ["Drone/DronePing"]
+        C:
+          description: "Continue clearing with extra lookouts"
+          effects:
+            audio: ["Audio/GunfireShort"]
+            visual: ["FX/LookoutFlash"]
+
+    - stage: 5
+      name: "Exfiltration Plan"
+      decisions:
+        A:
+          description: "Defensive perimeter, call vehicles"
+          effects:
+            audio: ["Audio/RadioCall"]
+            visual: ["Vehicles/ArmoredVehicle"]
+        B:
+          description: "Silent fade through brush"
+          effects:
+            audio: ["Audio/FootstepsQuiet"]
+            visual: ["Brush/FoliageRustle"]
+        C:
+          description: "Noisy bounding breakout"
+          effects:
+            audio: ["Audio/GunfireLoop"]
+            visual: ["FX/FlashbangMultiple"]

--- a/Source/TacSim/DecisionWidget.cpp
+++ b/Source/TacSim/DecisionWidget.cpp
@@ -1,0 +1,45 @@
+#include "DecisionWidget.h"
+#include "Components/TextBlock.h"
+#include "Components/VerticalBox.h"
+#include "Components/Button.h"
+#include "Components/TextBlock.h"
+
+void UDecisionWidget::NativeConstruct()
+{
+    Super::NativeConstruct();
+    SetVisibility(ESlateVisibility::Hidden);
+}
+
+void UDecisionWidget::InitializeDecision(const FString& StageTitle, const TMap<FString, FString>& Options)
+{
+    SetVisibility(ESlateVisibility::Visible);
+    if (StageText)
+    {
+        StageText->SetText(FText::FromString(StageTitle));
+    }
+    ClearOptions();
+    for (auto& Elem : Options)
+    {
+        UButton* Btn = WidgetTree->ConstructWidget<UButton>(UButton::StaticClass());
+        UTextBlock* Label = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass());
+        Label->SetText(FText::FromString(Elem.Key + ": " + Elem.Value));
+        Btn->AddChild(Label);
+        Btn->OnClicked.AddDynamic(this, &UDecisionWidget::SelectOption);
+        Btn->WidgetTags.Add(FName(*Elem.Key));
+        OptionsList->AddChild(Btn);
+    }
+}
+
+void UDecisionWidget::ClearOptions()
+{
+    if (OptionsList)
+    {
+        OptionsList->ClearChildren();
+    }
+}
+
+void UDecisionWidget::SelectOption(FString OptionKey)
+{
+    OnDecisionSelected.Broadcast(OptionKey);
+    SetVisibility(ESlateVisibility::Hidden);
+}

--- a/Source/TacSim/DecisionWidget.h
+++ b/Source/TacSim/DecisionWidget.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "DecisionWidget.generated.h"
+
+declare_dynamic_multicast_delegate_oneparam(FOnDecisionSelected, FString, DecisionKey);
+
+UCLASS()
+class TACSIM_API UDecisionWidget : public UUserWidget
+{
+    GENERATED_BODY()
+
+public:
+    UFUNCTION(BlueprintCallable, Category="Decision")
+    void InitializeDecision(const FString& StageTitle, const TMap<FString, FString>& Options);
+
+    UPROPERTY(BlueprintAssignable, Category="Decision")
+    FOnDecisionSelected OnDecisionSelected;
+
+protected:
+    UFUNCTION(BlueprintCallable, Category="Decision")
+    void SelectOption(FString OptionKey);
+
+    UFUNCTION(BlueprintCallable, Category="Decision")
+    void ClearOptions();
+
+    virtual void NativeConstruct() override;
+
+private:
+    UPROPERTY(meta=(BindWidget))
+    class UTextBlock* StageText;
+
+    UPROPERTY(meta=(BindWidget))
+    class UVerticalBox* OptionsList;
+};

--- a/Source/TacSim/ScenarioManager.cpp
+++ b/Source/TacSim/ScenarioManager.cpp
@@ -1,0 +1,151 @@
+#include "ScenarioManager.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "Json.h"
+#include "JsonUtilities.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "Kismet/GameplayStatics.h"
+#include "DecisionWidget.h"
+
+AScenarioManager::AScenarioManager()
+{
+    PrimaryActorTick.bCanEverTick = false;
+}
+
+void AScenarioManager::BeginPlay()
+{
+    Super::BeginPlay();
+    LoadScenario(TEXT("example_scenario.json"));
+}
+
+void AScenarioManager::LoadScenario(const FString& ScenarioJsonFilename)
+{
+    FString FullPath = ScenarioFolderPath + ScenarioJsonFilename;
+    TSharedPtr<FJsonObject> JsonObject = LoadJsonObjectFromFile(FullPath);
+    if (JsonObject.IsValid())
+    {
+        ParseAndSpawn(JsonObject);
+    }
+    else
+    {
+        UE_LOG(LogTemp, Error, TEXT("Failed to load scenario: %s"), *FullPath);
+    }
+}
+
+TSharedPtr<FJsonObject> AScenarioManager::LoadJsonObjectFromFile(const FString& FullPath)
+{
+    FString JsonRaw;
+    if (!FFileHelper::LoadFileToString(JsonRaw, *FullPath))
+    {
+        return nullptr;
+    }
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonRaw);
+    if (FJsonSerializer::Deserialize(Reader, JsonObject))
+    {
+        return JsonObject;
+    }
+    return nullptr;
+}
+
+void AScenarioManager::ParseAndSpawn(const TSharedPtr<FJsonObject>& JsonObject)
+{
+    if (!JsonObject->HasTypedField<EJson::Object>("scenario")) return;
+
+    TSharedPtr<FJsonObject> ScenarioRoot = JsonObject->GetObjectField(TEXT("scenario"));
+
+    if (ScenarioRoot->HasField(TEXT("building")))
+    {
+        SpawnEnvironment(ScenarioRoot->GetObjectField(TEXT("building")));
+    }
+
+    if (ScenarioRoot->HasField(TEXT("actors")))
+    {
+        SpawnActors(ScenarioRoot->GetArrayField(TEXT("actors")));
+    }
+
+    if (ScenarioRoot->HasField(TEXT("stages")))
+    {
+        const TArray<TSharedPtr<FJsonValue>>& StagesArray = ScenarioRoot->GetArrayField(TEXT("stages"));
+        if (StagesArray.Num() > 0)
+        {
+            TSharedPtr<FJsonObject> StageObj = StagesArray[0]->AsObject();
+            FString StageName = StageObj->GetStringField(TEXT("name"));
+            TSharedPtr<FJsonObject> DecisionsObj = StageObj->GetObjectField(TEXT("decisions"));
+            TMap<FString, FString> OptionsMap;
+            for (auto& Pair : DecisionsObj->Values)
+            {
+                OptionsMap.Add(Pair.Key, Pair.Value->AsObject()->GetStringField(TEXT("description")));
+            }
+            if (DecisionWidgetClass)
+            {
+                UWorld* World = GetWorld();
+                APlayerController* PC = UGameplayStatics::GetPlayerController(World, 0);
+                UDecisionWidget* DecWidget = CreateWidget<UDecisionWidget>(PC, DecisionWidgetClass);
+                if (DecWidget)
+                {
+                    DecWidget->AddToViewport();
+                    DecWidget->InitializeDecision(StageName, OptionsMap);
+                    DecWidget->OnDecisionSelected.AddDynamic(this, &AScenarioManager::OnStageDecision);
+                }
+            }
+        }
+    }
+}
+
+void AScenarioManager::SpawnEnvironment(const TSharedPtr<FJsonObject>& BuildingObj)
+{
+    FString Type = BuildingObj->GetStringField(TEXT("type"));
+    if (Type.Equals(TEXT("Townhouse_3Floor")))
+    {
+        FString AssetPath = TEXT("/Game/Buildings/Townhouse_3Floor.Townhouse_3Floor");
+        UStaticMesh* Mesh = Cast<UStaticMesh>(StaticLoadObject(UStaticMesh::StaticClass(), nullptr, *AssetPath));
+        if (Mesh)
+        {
+            FVector Loc;
+            Loc.X = BuildingObj->GetObjectField(TEXT("location"))->GetNumberField(TEXT("x"));
+            Loc.Y = BuildingObj->GetObjectField(TEXT("location"))->GetNumberField(TEXT("y"));
+            Loc.Z = BuildingObj->GetObjectField(TEXT("location"))->GetNumberField(TEXT("z"));
+            float Yaw = BuildingObj->GetObjectField(TEXT("rotation"))->GetNumberField(TEXT("yaw"));
+            FTransform Transform(FRotator(0, Yaw, 0), Loc);
+            AStaticMeshActor* MeshActor = GetWorld()->SpawnActor<AStaticMeshActor>(AStaticMeshActor::StaticClass(), Transform);
+            MeshActor->GetStaticMeshComponent()->SetStaticMesh(Mesh);
+            MeshActor->SetMobility(EComponentMobility::Static);
+        }
+    }
+}
+
+void AScenarioManager::SpawnActors(const TArray<TSharedPtr<FJsonValue>>& ActorsArray)
+{
+    for (auto& Val : ActorsArray)
+    {
+        TSharedPtr<FJsonObject> ActorObj = Val->AsObject();
+        FString Type = ActorObj->GetStringField(TEXT("type"));
+        float X = ActorObj->GetObjectField(TEXT("spawn"))->GetNumberField(TEXT("x"));
+        float Y = ActorObj->GetObjectField(TEXT("spawn"))->GetNumberField(TEXT("y"));
+        float Z = ActorObj->GetObjectField(TEXT("spawn"))->GetNumberField(TEXT("z"));
+        FVector SpawnLoc(X, Y, Z);
+        FRotator SpawnRot(0, 0, 0);
+        UClass* PawnClass = nullptr;
+        if (Type.Equals(TEXT("Friendly")))
+        {
+            static ConstructorHelpers::FClassFinder<APawn> FriendlyBP(TEXT("/Game/Blueprints/BP_FriendlyPawn"));
+            PawnClass = FriendlyBP.Class;
+        }
+        else if (Type.Equals(TEXT("Enemy")))
+        {
+            static ConstructorHelpers::FClassFinder<APawn> EnemyBP(TEXT("/Game/Blueprints/BP_EnemyPawn"));
+            PawnClass = EnemyBP.Class;
+        }
+        if (PawnClass)
+        {
+            GetWorld()->SpawnActor<APawn>(PawnClass, SpawnLoc, SpawnRot);
+        }
+    }
+}
+
+void AScenarioManager::OnStageDecision(FString DecisionKey)
+{
+    UE_LOG(LogTemp, Log, TEXT("User selected decision: %s"), *DecisionKey);
+}

--- a/Source/TacSim/ScenarioManager.h
+++ b/Source/TacSim/ScenarioManager.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "ScenarioManager.generated.h"
+
+UCLASS(Blueprintable)
+class TACSIM_API AScenarioManager : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AScenarioManager();
+
+protected:
+    virtual void BeginPlay() override;
+
+    UFUNCTION(BlueprintCallable, Category="Scenario")
+    void LoadScenario(const FString& ScenarioJsonFilename);
+
+private:
+    void ParseAndSpawn(const TSharedPtr<FJsonObject>& JsonObject);
+    void SpawnEnvironment(const TSharedPtr<FJsonObject>& BuildingObj);
+    void SpawnActors(const TArray<TSharedPtr<FJsonValue>>& ActorsArray);
+    FString ScenarioFolderPath = FPaths::ProjectContentDir() + "Scenarios/";
+    TSharedPtr<FJsonObject> LoadJsonObjectFromFile(const FString& FullPath);
+
+    UPROPERTY(EditAnywhere, Category="UI")
+    TSubclassOf<class UDecisionWidget> DecisionWidgetClass;
+
+    UFUNCTION()
+    void OnStageDecision(FString DecisionKey);
+};

--- a/Source/TacSim/TacSim.Build.cs
+++ b/Source/TacSim/TacSim.Build.cs
@@ -1,0 +1,24 @@
+using UnrealBuildTool;
+
+public class TacSim : ModuleRules
+{
+    public TacSim(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicDependencyModuleNames.AddRange(
+            new string[]
+            {
+                "Core",
+                "CoreUObject",
+                "Engine",
+                "InputCore",
+                "UMG",
+                "Json",
+                "JsonUtilities",
+                "HeadMountedDisplay",
+            }
+        );
+        PrivateDependencyModuleNames.AddRange(new string[] { });
+    }
+}

--- a/Source/TacSim/TacSim.cpp
+++ b/Source/TacSim/TacSim.cpp
@@ -1,0 +1,19 @@
+#include "TacSim.h"
+#include "Modules/ModuleManager.h"
+#include "Engine/Engine.h"
+
+#define LOCTEXT_NAMESPACE "FTacSimModule"
+
+void FTacSimModule::StartupModule()
+{
+    UE_LOG(LogTemp, Log, TEXT("TacSim module started"));
+}
+
+void FTacSimModule::ShutdownModule()
+{
+    UE_LOG(LogTemp, Log, TEXT("TacSim module shutting down"));
+}
+
+#undef LOCTEXT_NAMESPACE
+
+IMPLEMENT_PRIMARY_GAME_MODULE(FTacSimModule, TacSim, "TacSim");

--- a/Source/TacSim/TacSim.h
+++ b/Source/TacSim/TacSim.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Modules/ModuleManager.h"
+
+class FTacSimModule : public IModuleInterface
+{
+public:
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
+};

--- a/Source/TacSim/VRPawn.cpp
+++ b/Source/TacSim/VRPawn.cpp
@@ -1,0 +1,42 @@
+#include "VRPawn.h"
+#include "Camera/CameraComponent.h"
+#include "Components/SceneComponent.h"
+#include "MotionControllerComponent.h"
+#include "HeadMountedDisplayFunctionLibrary.h"
+#include "XRMotionControllerBase.h"
+
+AVRPawn::AVRPawn()
+{
+    PrimaryActorTick.bCanEverTick = true;
+
+    VROrigin = CreateDefaultSubobject<USceneComponent>(TEXT("VROrigin"));
+    RootComponent = VROrigin;
+
+    CameraComponent = CreateDefaultSubobject<UCameraComponent>(TEXT("CameraComponent"));
+    CameraComponent->SetupAttachment(VROrigin);
+    CameraComponent->bUsePawnControlRotation = false;
+
+    LeftController = CreateDefaultSubobject<UMotionControllerComponent>(TEXT("LeftController"));
+    LeftController->SetupAttachment(VROrigin);
+    LeftController->SetTrackingSource(EControllerHand::Left);
+
+    RightController = CreateDefaultSubobject<UMotionControllerComponent>(TEXT("RightController"));
+    RightController->SetupAttachment(VROrigin);
+    RightController->SetTrackingSource(EControllerHand::Right);
+}
+
+void AVRPawn::BeginPlay()
+{
+    Super::BeginPlay();
+    UHeadMountedDisplayFunctionLibrary::EnableHMD(true);
+}
+
+void AVRPawn::Tick(float DeltaTime)
+{
+    Super::Tick(DeltaTime);
+}
+
+void AVRPawn::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
+{
+    Super::SetupPlayerInputComponent(PlayerInputComponent);
+}

--- a/Source/TacSim/VRPawn.h
+++ b/Source/TacSim/VRPawn.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Pawn.h"
+#include "VRPawn.generated.h"
+
+UCLASS()
+class TACSIM_API AVRPawn : public APawn
+{
+    GENERATED_BODY()
+
+public:
+    AVRPawn();
+
+protected:
+    virtual void BeginPlay() override;
+
+public:
+    virtual void Tick(float DeltaTime) override;
+    virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
+
+private:
+    UPROPERTY(VisibleAnywhere)
+    class UCameraComponent* CameraComponent;
+
+    UPROPERTY(VisibleAnywhere)
+    class UMotionControllerComponent* LeftController;
+
+    UPROPERTY(VisibleAnywhere)
+    class UMotionControllerComponent* RightController;
+
+    UPROPERTY(VisibleAnywhere)
+    class USceneComponent* VROrigin;
+};

--- a/Tools/parse_scenario.py
+++ b/Tools/parse_scenario.py
@@ -1,0 +1,17 @@
+import yaml
+import json
+import os
+
+YAML_PATH = os.path.join('Content', 'Scenarios', 'example_scenario.yaml')
+JSON_PATH = os.path.join('Content', 'Scenarios', 'example_scenario.json')
+
+def main():
+    with open(YAML_PATH, 'r') as yf:
+        data = yaml.safe_load(yf)
+
+    with open(JSON_PATH, 'w') as jf:
+        json.dump(data, jf, indent=2)
+    print(f"Converted {YAML_PATH} -> {JSON_PATH}")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Unreal Engine 5 C++ skeleton with `TacSim` module
- include `ScenarioManager`, `VRPawn`, and `DecisionWidget` classes
- provide example YAML scenario and Python converter to JSON

## Testing
- `pip install pyyaml`
- `python3 Tools/parse_scenario.py`
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6840a47716c4832e97bfdf6ca72e5148