### PR TITLE
Remove drone/vehicle references and document assets

### DIFF
--- a/Content/Scenarios/example_scenario.json
+++ b/Content/Scenarios/example_scenario.json
@@ -68,7 +68,7 @@
             "description": "Suppressive fire on the house"
           },
           "B": {
-            "description": "Launch a daylight drone for recon"
+            "description": "Send a lookout for recon"
           },
           "C": {
             "description": "Silent breach attempt"
@@ -113,7 +113,7 @@
             "description": "Halt and fortify inside"
           },
           "B": {
-            "description": "Deploy drone while clearing"
+            "description": "Assign extra lookout while clearing"
           },
           "C": {
             "description": "Continue clearing with extra lookouts"
@@ -125,7 +125,7 @@
         "name": "Exfiltration Plan",
         "decisions": {
           "A": {
-            "description": "Defensive perimeter, call vehicles"
+            "description": "Defensive perimeter, await pickup"
           },
           "B": {
             "description": "Silent fade through brush"

--- a/Content/Scenarios/example_scenario.yaml
+++ b/Content/Scenarios/example_scenario.yaml
@@ -39,7 +39,7 @@ scenario:
         A:
           description: "Suppressive fire on the house"
         B:
-          description: "Launch a daylight drone for recon"
+          description: "Send a lookout for recon"
         C:
           description: "Silent breach attempt"
 
@@ -69,7 +69,7 @@ scenario:
         A:
           description: "Halt and fortify inside"
         B:
-          description: "Deploy drone while clearing"
+          description: "Assign extra lookout while clearing"
         C:
           description: "Continue clearing with extra lookouts"
 
@@ -77,7 +77,7 @@ scenario:
       name: "Exfiltration Plan"
       decisions:
         A:
-          description: "Defensive perimeter, call vehicles"
+          description: "Defensive perimeter, await pickup"
         B:
           description: "Silent fade through brush"
         C:


### PR DESCRIPTION
## Summary
- modify scenario files to avoid drone/vehicle references
- keep a trimmed list of optional FX and audio cues in `docs/enhanced_vr.md`
- provide prompts for generating minimal assets in `docs/asset_prompts.md`

## Testing
- `npm install`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68417ec89b80832ea2592474826abe31