### PR TITLE
Add installation guide and scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20
+
+# Install git-lfs
+RUN apt-get update && \
+    apt-get install -y git-lfs && \
+    git lfs install && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+RUN npm install && npm run build
+
+EXPOSE 5000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ training simulator. The `/unreal` folder holds the Unreal Engine project used
 for VR scenes while the `/server` and `/client` folders contain the Node.js API
 and React front‑end.
 
+## Installation
+
+See [`docs/INSTALLATION.md`](docs/INSTALLATION.md) for full setup instructions,
+including helper scripts for macOS, Linux and Docker.
+
 ## Running the Web App
 
 ```

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,78 @@
+# Installation Guide
+
+This document explains how to set up **ActSim** and all required dependencies on macOS, Linux and inside Docker. The web application consists of a Node.js API and React front end. A PostgreSQL database is required for persistent storage and Git LFS is used for large assets such as Unreal Engine files.
+
+## Prerequisites
+
+- **Git** and **Git LFS**
+- **Node.js** (recommended Node 20 or newer)
+- **npm** (bundled with Node.js)
+- **PostgreSQL** server
+- **Unreal Engine 5** for building the optional VR demo
+
+Clone the repository and pull LFS files:
+
+```bash
+git clone https://github.com/your-org/ActSim.git
+cd ActSim
+git lfs install
+git lfs pull
+```
+
+Create a PostgreSQL database and note the connection string. Export it as `DATABASE_URL` before running the server. Example:
+
+```bash
+export DATABASE_URL=postgres://user:password@localhost:5432/actsim
+```
+
+Install Node dependencies and run database migrations:
+
+```bash
+npm install
+npm run db:push
+```
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+The API and front end will be available on [http://localhost:5000](http://localhost:5000).
+
+### Building for Production
+
+```bash
+npm run build
+npm start
+```
+
+The compiled application lives in the `dist/` directory and listens on port `5000`.
+
+## Platform Specific Setup
+
+### macOS
+Run the helper script which installs Homebrew, Node.js, Git LFS and PostgreSQL:
+
+```bash
+./scripts/install-mac.sh
+```
+
+### Linux (Ubuntu/Debian)
+Run the Linux setup script to install Node.js, Git LFS and PostgreSQL packages:
+
+```bash
+./scripts/install-linux.sh
+```
+
+### Docker
+A Dockerfile is provided to build a self‑contained image. Ensure `DATABASE_URL` is accessible from inside the container.
+
+```bash
+./scripts/run-docker.sh
+```
+
+This builds the image and starts it on port `5000`.
+
+## Unreal VR Demo
+The VR scenario is located under `unreal/`. Install Unreal Engine 5.4 or newer, open `TACSIM.uproject` and enable the OpenXR plugin. See `unreal/README.md` for details on packaging the project for Meta Quest.

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# Update package lists
+sudo apt-get update
+
+# Install Node.js from NodeSource
+if ! command -v node >/dev/null 2>&1; then
+  curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+  sudo apt-get install -y nodejs
+fi
+
+# Install git-lfs
+if ! command -v git-lfs >/dev/null 2>&1; then
+  sudo apt-get install -y git-lfs
+  git lfs install
+fi
+
+# Install Postgres (optional for local testing)
+if ! command -v psql >/dev/null 2>&1; then
+  sudo apt-get install -y postgresql
+fi
+
+echo "Installing npm dependencies"
+npm install
+
+cat <<EOM
+Setup complete. Configure the DATABASE_URL environment variable before running the server:
+  export DATABASE_URL=postgres://user:password@localhost:5432/actsim
+Run the development server with:
+  npm run dev
+EOM

--- a/scripts/install-mac.sh
+++ b/scripts/install-mac.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+# Install Homebrew if not installed
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Installing Homebrew..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+
+# Install Node.js (latest LTS)
+if ! command -v node >/dev/null 2>&1; then
+  brew install node@20
+fi
+
+# Install git-lfs
+if ! command -v git-lfs >/dev/null 2>&1; then
+  brew install git-lfs
+  git lfs install
+fi
+
+# Install Postgres (optional for local testing)
+if ! command -v psql >/dev/null 2>&1; then
+  brew install postgresql
+fi
+
+echo "Installing npm dependencies"
+npm install
+
+cat <<EOM
+Setup complete. Configure the DATABASE_URL environment variable before running the server:
+  export DATABASE_URL=postgres://user:password@localhost:5432/actsim
+Run the development server with:
+  npm run dev
+EOM

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+docker build -t actsim .
+docker run --rm -p 5000:5000 -e DATABASE_URL=$DATABASE_URL actsim


### PR DESCRIPTION
## Summary
- document installation steps in docs/INSTALLATION.md
- link to new installation guide from README
- add helper scripts for macOS, Linux and Docker
- provide Dockerfile for containerized usage

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node', 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6841f6165a6c832ebcf7b24abbdc99a5