### PR TITLE
Update setup scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install
 npm run dev
 ```
 
-The server will start on port `5000` and host both the API and the front‑end.
+The server will start on [http://127.0.0.1:5000](http://127.0.0.1:5000) and host both the API and the front‑end.
 
 ## Type Checking
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -22,7 +22,7 @@ git lfs pull
 Create a PostgreSQL database and note the connection string. Export it as `DATABASE_URL` before running the server. Example:
 
 ```bash
-export DATABASE_URL=postgres://user:password@localhost:5432/actsim
+export DATABASE_URL=postgres://user:password@127.0.0.1:5432/actsim
 ```
 
 Install Node dependencies and run database migrations:
@@ -38,7 +38,7 @@ Start the development server:
 npm run dev
 ```
 
-The API and front end will be available on [http://localhost:5000](http://localhost:5000).
+The API and front end will be available on [http://127.0.0.1:5000](http://127.0.0.1:5000).
 
 ### Building for Production
 

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -24,9 +24,12 @@ fi
 echo "Installing npm dependencies"
 npm install
 
+echo "Running database migrations"
+npm run db:push
+
 cat <<EOM
 Setup complete. Configure the DATABASE_URL environment variable before running the server:
-  export DATABASE_URL=postgres://user:password@localhost:5432/actsim
+  export DATABASE_URL=postgres://user:password@127.0.0.1:5432/actsim
 Run the development server with:
   npm run dev
 EOM

--- a/scripts/install-mac.sh
+++ b/scripts/install-mac.sh
@@ -27,9 +27,12 @@ fi
 echo "Installing npm dependencies"
 npm install
 
+echo "Running database migrations"
+npm run db:push
+
 cat <<EOM
 Setup complete. Configure the DATABASE_URL environment variable before running the server:
-  export DATABASE_URL=postgres://user:password@localhost:5432/actsim
+  export DATABASE_URL=postgres://user:password@127.0.0.1:5432/actsim
 Run the development server with:
   npm run dev
 EOM

--- a/server/index.ts
+++ b/server/index.ts
@@ -63,7 +63,8 @@ app.use((req, res, next) => {
   // use a simple listen call for broad platform compatibility
   server.listen({
     port,
-    host: "0.0.0.0",
+    // bind specifically to the loopback interface
+    host: "127.0.0.1",
   }, () => {
     log(`serving on port ${port}`);
   });


### PR DESCRIPTION
## Summary
- bind the server to 127.0.0.1
- run database migrations in install scripts
- document explicit loopback host

## Testing
- `npm run check`
- `npm run build`
- `npm run db:push` *(fails: DATABASE_URL not set)*

------
https://chatgpt.com/codex/tasks/task_e_68429a8ed4cc832eb082c0ac1efdd791