### PR TITLE
Add Python asset viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,14 @@ Prompts for generating the core placeholder assets are in [`docs/asset_prompts.m
 ## Git LFS
 
 Large binary assets such as Unreal Engine resources are stored using [Git LFS](https://git-lfs.github.com/). Install Git LFS and run `git lfs install` before working with the repo. After cloning, execute `git lfs pull` to download any large files.
+
+## Asset Viewer
+
+The `Tools/view_asset.py` script can be used to quickly preview meshes in the
+`assets/` directory. It relies only on [Open3D](https://www.open3d.org/), which
+is available on Windows, macOS and Linux.
+
+```bash
+pip install open3d
+./Tools/view_asset.py assets/scene_ME.obj
+```

--- a/Tools/view_asset.py
+++ b/Tools/view_asset.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Simple 3D asset viewer.
+
+This script loads a 3D model file (e.g. OBJ or FBX) and displays it using
+Open3D. It is completely standalone and does not rely on any of the
+simulation logic in the web app.
+"""
+
+import argparse
+import os
+import sys
+
+import open3d as o3d
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Preview a 3D asset")
+    parser.add_argument("path", help="Path to the model file to display")
+    args = parser.parse_args()
+
+    asset_path = os.path.abspath(args.path)
+    if not os.path.exists(asset_path):
+        sys.exit(f"File not found: {asset_path}")
+
+    mesh = o3d.io.read_triangle_mesh(asset_path)
+    if mesh.is_empty():
+        sys.exit(f"Unable to load mesh from {asset_path}")
+
+    mesh.compute_vertex_normals()
+    o3d.visualization.draw(mesh, title=os.path.basename(asset_path))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `Tools/view_asset.py` for quick asset previews
- document how to use the viewer in `README.md`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6845ef9fba28832e91813f5e8595faa9