### PR TITLE
Improve Open3D guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ Large binary assets such as Unreal Engine resources are stored using [Git LFS](h
 ## Asset Viewer
 
 The `Tools/view_asset.py` script can be used to quickly preview meshes in the
-`assets/` directory. It relies only on [Open3D](https://www.open3d.org/), which
-is available on Windows, macOS and Linux.
+`assets/` directory. It relies on [Open3D](https://www.open3d.org/).
+
+**Note:** Open3D distributes wheels for Python 3.12 and earlier. On Python
+3.13 you may need to build Open3D from source or use an older interpreter to
+run this viewer.
 
 ```bash
 pip install open3d
-./Tools/view_asset.py assets/scene_ME.obj
+python3 Tools/view_asset.py assets/scene_ME.obj
 ```

--- a/Tools/view_asset.py
+++ b/Tools/view_asset.py
@@ -10,7 +10,18 @@ import argparse
 import os
 import sys
 
-import open3d as o3d
+try:
+    import open3d as o3d
+except Exception as exc:
+    message = f"Failed to import Open3D: {exc}"
+    if sys.version_info >= (3, 13):
+        message += (
+            "\nOpen3D provides wheels only for Python 3.12 and earlier. "
+            "You can build Open3D from source or run this tool with an older Python release."
+        )
+    else:
+        message += "\nInstall Open3D with 'pip install open3d'."
+    sys.exit(message)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- refine the Open3D import logic so Python 3.13 can still attempt to run
- clarify README instructions for Python 3.13 users

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68472bdb1eb0832e984a24d50bfa51d3